### PR TITLE
fix: playlist page alingment

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -119,10 +119,6 @@ tp-yt-app-drawer,
     display: none !important;
 }
 
-#page-manager {
-    margin-left: 0 !important;
-}
-
 .ytp-chrome-bottom {
     width: calc(98%) !important;
 }


### PR DESCRIPTION
Fixing this issue:
https://github.com/ephraimduncan/minimal-youtube/issues/30

Before:
![image](https://github.com/ephraimduncan/minimal-youtube/assets/16908590/fbfd2e28-07b6-4530-97e4-73e743d68b92)

After:
![image](https://github.com/ephraimduncan/minimal-youtube/assets/16908590/09b708a6-ae0c-45ca-aef2-dbf98896052b)

This has a side effect though: The search page will be a little bit more to the right. But I think it is not a big deal.

Search page before:
![image](https://github.com/ephraimduncan/minimal-youtube/assets/16908590/e530b81c-b909-427b-a110-3ca00db9b90a)



Search page after:
![image](https://github.com/ephraimduncan/minimal-youtube/assets/16908590/b2d50c72-93eb-4389-b2d1-efc3a0bebb1d)
